### PR TITLE
refactor: revert previous input type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@macpaw/macpaw-ui",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@macpaw/macpaw-ui",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "MIT",
       "dependencies": {
         "react-toastify": "^7.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macpaw/macpaw-ui",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "main": "lib/ui.js",
   "scripts": {
     "dev": "next -p 1234",

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -11,7 +11,6 @@ import cx from 'clsx';
 import Hint from '../Hint/Hint';
 import { Error as InputError, InputValueType } from '../types';
 
-type InputElementType = HTMLInputElement | HTMLTextAreaElement;
 
 export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   scale?: 'medium' | 'small' | 'big';
@@ -23,11 +22,11 @@ export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
   currency?: string;
   formatOnEvent?: 'blur' | 'input';
   format?: (value: InputValueType) => InputValueType;
-  onChange?: (value:InputValueType, event?: React.ChangeEvent<InputElementType>) => void;
+  onChange?: (value:InputValueType, event?: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 
-const Input = forwardRef<InputElementType, InputProps>((props, ref) => {
+const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const {
     type = 'text',
     multiline = false,
@@ -46,7 +45,7 @@ const Input = forwardRef<InputElementType, InputProps>((props, ref) => {
   } = props;
 
   const isDirtyRef = useRef(false);
-  const inputRef = useRef<InputElementType>();
+  const inputRef = useRef<HTMLInputElement>();
 
   const classNames = cx('input', {
     '-error': Boolean(error),
@@ -76,7 +75,7 @@ const Input = forwardRef<InputElementType, InputProps>((props, ref) => {
     throw Error('action and currency cannot be set at the same time');
   }
 
-  const setRef = (element: InputElementType) => {
+  const setRef = (element: HTMLInputElement) => {
     if (typeof ref === 'function') ref(element);
     else if (ref) ref.current = element;
 
@@ -86,7 +85,7 @@ const Input = forwardRef<InputElementType, InputProps>((props, ref) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!isDirtyRef.current) isDirtyRef.current = true;
 
-    const inputValue = (event.target as InputElementType).value;
+    const inputValue = (event.target as HTMLInputElement).value;
     onChange?.(inputValue, event);
   };
 
@@ -96,7 +95,7 @@ const Input = forwardRef<InputElementType, InputProps>((props, ref) => {
     if (!formatOnEvent || !input) return () => {};
 
     const handleFormatOnEvent = (event: InputEvent | FocusEvent) => {
-      const inputValue = (event.target as InputElementType).value;
+      const inputValue = (event.target as HTMLInputElement).value;
       onChange?.(format?.(inputValue) ?? inputValue);
     };
 

--- a/src/Password/Password.tsx
+++ b/src/Password/Password.tsx
@@ -10,7 +10,7 @@ export interface PasswordProps extends Omit<InputHTMLAttributes<HTMLInputElement
   withToggle?: boolean;
   i18nToggle?: (isPasswordVisible: boolean) => string;
   onToggle?: () => void;
-  onChange?:(value: InputValueType, event?: React.ChangeEvent) => void;
+  onChange?:(value: InputValueType, event?: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 function i18nToggleDefault(isPasswordVisible: boolean) {


### PR DESCRIPTION
`InputElementType` type is more descriptive but it leads to many typing errors.
I think in the future when we need specific textarea properties, we should split this component into several specific (Input & Textarea)