### PR TITLE
fix: add mastercard payment type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macpaw/macpaw-ui",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "main": "lib/ui.js",
   "scripts": {
     "dev": "next -p 1234",

--- a/src/Payment/Payment.tsx
+++ b/src/Payment/Payment.tsx
@@ -11,7 +11,7 @@ import UnionPay from '../Icons/jsx/PaymentUnionPay';
 import Visa from '../Icons/jsx/PaymentVisa';
 
 export interface PaymentProps extends HTMLAttributes<SVGElement> {
-  type?: 'paypal' | 'american_express' | 'diners_club' | 'discover' | 'jcb' | 'maestro' | 'unionpay' | 'visa' | 'master';
+  type?: 'paypal' | 'american_express' | 'diners_club' | 'discover' | 'jcb' | 'maestro' | 'unionpay' | 'visa' | 'master' | 'mastercard';
 }
 
 const Payment: FC<React.PropsWithChildren<PaymentProps>> = (props) => {
@@ -35,6 +35,7 @@ const Payment: FC<React.PropsWithChildren<PaymentProps>> = (props) => {
     case 'visa':
       return <Visa {...other} />;
     case 'master':
+    case 'mastercard':
       return <Master {...other} />;
     default:
       return <Card {...other} />;


### PR DESCRIPTION
Due to unexpected changes from Paddle (they've changed payment type for MasterCard from `master` to `mastercard`) I've added it to Payment component. 