### PR TITLE
[Frontend] feat: dropdown misclick

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       timezone: "Europe/Kyiv"
     open-pull-requests-limit: 2
     reviewers:
-      - MacPaw/platform-frontend
+      - "MacPaw/platform-frontend"
     allowed_updates:
       - match:
           update_type: "security"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@macpaw/macpaw-ui",
-  "version": "4.6.5",
+  "version": "4.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@macpaw/macpaw-ui",
-      "version": "4.6.5",
+      "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.29.3",
+        "lodash.debounce": "^4.0.8",
         "react-day-picker": "^8.3.7",
         "react-toastify": "^7.0.4"
       },
@@ -20,6 +21,7 @@
         "@mdx-js/loader": "^2.1.1",
         "@next/mdx": "^12.1.6",
         "@svgr/cli": "^6.3.1",
+        "@types/lodash.debounce": "^4.0.7",
         "@types/node": "^16.4.3",
         "@types/react": "^18.0.10",
         "@types/react-dom": "^18.0.5",
@@ -1345,6 +1347,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.192",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
+      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz",
+      "integrity": "sha512-X1T4wMZ+gT000M2/91SYj0d/7JfeNZ9PeeOldSNoE/lunLeQXKvkmIumI29IaKMotU/ln/McOIvgzZcQ/3TrSA==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -5212,6 +5229,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -9917,6 +9939,21 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.192",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
+      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==",
+      "dev": true
+    },
+    "@types/lodash.debounce": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz",
+      "integrity": "sha512-X1T4wMZ+gT000M2/91SYj0d/7JfeNZ9PeeOldSNoE/lunLeQXKvkmIumI29IaKMotU/ln/McOIvgzZcQ/3TrSA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mdast": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
@@ -12833,6 +12870,11 @@
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
       }
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macpaw/macpaw-ui",
-  "version": "4.6.5",
+  "version": "4.7.0",
   "main": "lib/ui.js",
   "scripts": {
     "dev": "next -p 1234",
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "date-fns": "^2.29.3",
+    "lodash.debounce": "^4.0.8",
     "react-day-picker": "^8.3.7",
     "react-toastify": "^7.0.4"
   },
@@ -38,6 +39,7 @@
     "@mdx-js/loader": "^2.1.1",
     "@next/mdx": "^12.1.6",
     "@svgr/cli": "^6.3.1",
+    "@types/lodash.debounce": "^4.0.7",
     "@types/node": "^16.4.3",
     "@types/react": "^18.0.10",
     "@types/react-dom": "^18.0.5",

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -9,7 +9,7 @@ export interface Dropdown extends HTMLAttributes<HTMLDivElement> {
   onClose?: () => void;
 }
 
-const VISIBILITY_DELAY = 150;
+const VISIBILITY_DELAY = 100;
 
 const DropDown: React.FC<React.PropsWithChildren<Dropdown>> = (props) => {
   const { className, children, trigger, position, onOpen, onClose, ...other } = props;

--- a/src/DropdownItem/DropdownItem.tsx
+++ b/src/DropdownItem/DropdownItem.tsx
@@ -8,14 +8,22 @@ export interface DropdownItem extends ButtonHTMLAttributes<HTMLButtonElement> {
   withoutAction?: boolean;
   separator?: boolean;
   to?: string;
+  onClick?: () => void | Promise<void>;
 }
 
 const DropdownItem: React.FC<React.PropsWithChildren<DropdownItem>> = (props) => {
-  const { children, component = 'button', className, attention, withoutAction, separator, ...other } = props;
+  const {
+    children,
+    component = 'button',
+    className, attention,
+    withoutAction,
+    separator,
+    href,
+    ...other } = props;
 
   let Component = component as ElementType;
 
-  if (Component === 'button' && other.href) {
+  if (Component === 'button' && href) {
     Component = 'a';
   }
 

--- a/src/DropdownItem/DropdownItem.tsx
+++ b/src/DropdownItem/DropdownItem.tsx
@@ -8,7 +8,6 @@ export interface DropdownItem extends ButtonHTMLAttributes<HTMLButtonElement> {
   withoutAction?: boolean;
   separator?: boolean;
   to?: string;
-  onClick?: () => void | Promise<void>;
 }
 
 const DropdownItem: React.FC<React.PropsWithChildren<DropdownItem>> = (props) => {


### PR DESCRIPTION
Problem: on the dropdown closing we set CSS style `visibility: hidden`, which sometimes doesn't fire the `click` event on the child menu because the parent element (dropdown) already has `visibility: hidden` at the moment. As a solution, I added a delay (150ms) before setting `visibility: hidden`, which allows the browser to handle the `click` event correctly.